### PR TITLE
feat: implement issue #69 message groups (1.0)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -74,6 +74,25 @@ The goal is consistency, correctness, and alignment with the plugin architecture
 - Do not introduce heavy external libraries for features that can be implemented with existing stack.
 
 ## Release And Branch Rules
+- Every issue in this codebase, including CI-related issues, must be worked on a dedicated branch.
+- Dedicated work branches must use the `feature/` prefix.
+- Branch naming convention for issue work:
+	- `master` target: `feature/<issue-number>-<short-description>` (example: `feature/69-message-groups`)
+	- `1.0` target: `feature/<issue-number>-<short-description>-1.0` (example: `feature/69-message-groups-1.0`)
+	- CI tasks without an issue number should still use a `feature/` branch with a descriptive slug (example: `feature/ci-fix-green-checks`)
+- Mandatory pre-work branch verification:
+	- Before making any code or doc change, verify the current branch name and target line.
+	- If the current branch is not the intended target branch for the task, switch first to the correct branch (or create it from the correct baseline) and only then start editing.
+	- A branch ending with `-1.0` must be based on the `1.0` release branch (not on `master`).
+	- Validate branch ancestry explicitly (for example with `git merge-base --is-ancestor 1.0 HEAD`) before starting work on `-1.0` branches.
+	- If branch naming, ancestry, and target baseline are inconsistent, stop and fix/switch the branch first.
+- Version-line UI framework compatibility check:
+	- `1.0` line must stay aligned with PatternFly 5 compatibility.
+	- `master` (2.x line) is the branch where PatternFly 6 support is expected.
+	- If a branch baseline implies a different PatternFly major than what the workspace currently resolves, pause and reconcile branch/baseline before continuing.
+- Root branches are reserved for releases only.
+- `master` is the mainline branch.
+- `1.0` is a release line branch for the 1.x stream.
 - If a change is compatible with both versions, apply it on both `master` and `1.0` branches.
 - If a change is not compatible with `1.0`, document why and keep it `master`-only.
 - PatternFly-version-specific fixes should be evaluated per branch and applied where applicable.
@@ -83,6 +102,11 @@ The goal is consistency, correctness, and alignment with the plugin architecture
 - The `origin` remote is a backup remote and should not be treated as the default target.
 - Prefer `github` for pull, fetch, push, branch tracking, and PR-related workflows.
 - Use `origin` only when explicitly requested for backup synchronization.
+
+## Pull Request Rules
+- Before final approval/merge, PR branches in review should have their work commits squashed to keep history clean and readable.
+- When opening a PR, always use the repository template in `.github/pull_request_template.md`.
+- Do not open PRs with an empty or ad-hoc description when the template is available; fill in all relevant sections.
 
 ## Constraints
 - Do not modify the ActiveMQ Classic JMX model.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -104,7 +104,7 @@ The goal is consistency, correctness, and alignment with the plugin architecture
 - Use `origin` only when explicitly requested for backup synchronization.
 
 ## Pull Request Rules
-- Before final approval/merge, PR branches in review should have their work commits squashed to keep history clean and readable.
+- When a PR is ready for merge, squashing commits is mandatory: always squash work commits to keep history clean and readable.
 - When opening a PR, always use the repository template in `.github/pull_request_template.md`.
 - Do not open PRs with an empty or ad-hoc description when the template is available; fill in all relevant sections.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,6 +13,7 @@ Explain what this PR changes and why.
 
 ## Checklist
 - [ ] My commits follow the Conventional Commits specification
+- [ ] If this PR is ready to merge, commits are squashed
 - [ ] I added screenshots if the UI was modified
 - [ ] I tested the changes locally
 - [ ] I updated documentation where needed

--- a/.github/workflows/build-1.0.yml
+++ b/.github/workflows/build-1.0.yml
@@ -99,12 +99,32 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_URL: ${{ secrets.SONAR_URL }}
         run: |
-          sonar-scanner \
-            -Dsonar.projectKey=activemq-classic-hawtio \
-            -Dsonar.projectName="ActiveMQ Classic Hawtio Plugin" \
-            -Dsonar.sources=src/main/java,frontend/src \
-            -Dsonar.java.binaries=target/classes \
-            -Dsonar.scanner.javaExePath="$JAVA_HOME/bin/java" \
-            -Dsonar.branch.name=${{ github.head_ref || github.ref_name }} \
-            -Dsonar.host.url=$SONAR_URL \
-            -Dsonar.token=$SONAR_TOKEN
+          SONAR_JAVA_LIBS="${HOME}/.m2/repository/**/*.jar"
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            sonar-scanner \
+              -Dsonar.projectKey=activemq-classic-hawtio \
+              -Dsonar.projectName="ActiveMQ Classic Hawtio Plugin" \
+              -Dsonar.sources=src/main/java,frontend/src \
+              -Dsonar.java.binaries=target/classes \
+              -Dsonar.java.libraries="$SONAR_JAVA_LIBS" \
+              -Dsonar.scanner.javaExePath="$JAVA_HOME/bin/java" \
+              -Dsonar.qualitygate.wait=false \
+              -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
+              -Dsonar.pullrequest.branch=${{ github.head_ref }} \
+              -Dsonar.pullrequest.base=${{ github.base_ref }} \
+              -Dsonar.host.url=$SONAR_URL \
+              -Dsonar.token=$SONAR_TOKEN
+          else
+            sonar-scanner \
+              -Dsonar.projectKey=activemq-classic-hawtio \
+              -Dsonar.projectName="ActiveMQ Classic Hawtio Plugin" \
+              -Dsonar.sources=src/main/java,frontend/src \
+              -Dsonar.java.binaries=target/classes \
+              -Dsonar.java.libraries="$SONAR_JAVA_LIBS" \
+              -Dsonar.scanner.javaExePath="$JAVA_HOME/bin/java" \
+              -Dsonar.qualitygate.wait=false \
+              -Dsonar.branch.name=${{ github.head_ref || github.ref_name }} \
+              -Dsonar.host.url=$SONAR_URL \
+              -Dsonar.token=$SONAR_TOKEN
+          fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,12 +99,32 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_URL: ${{ secrets.SONAR_URL }}
         run: |
-          sonar-scanner \
-            -Dsonar.projectKey=activemq-classic-hawtio \
-            -Dsonar.projectName="ActiveMQ Classic Hawtio Plugin" \
-            -Dsonar.sources=src/main/java,frontend/src \
-            -Dsonar.java.binaries=target/classes \
-            -Dsonar.scanner.javaExePath="$JAVA_HOME/bin/java" \
-            -Dsonar.branch.name=${{ github.head_ref || github.ref_name }} \
-            -Dsonar.host.url=$SONAR_URL \
-            -Dsonar.token=$SONAR_TOKEN
+          SONAR_JAVA_LIBS="${HOME}/.m2/repository/**/*.jar"
+
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            sonar-scanner \
+              -Dsonar.projectKey=activemq-classic-hawtio \
+              -Dsonar.projectName="ActiveMQ Classic Hawtio Plugin" \
+              -Dsonar.sources=src/main/java,frontend/src \
+              -Dsonar.java.binaries=target/classes \
+              -Dsonar.java.libraries="$SONAR_JAVA_LIBS" \
+              -Dsonar.scanner.javaExePath="$JAVA_HOME/bin/java" \
+              -Dsonar.qualitygate.wait=false \
+              -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} \
+              -Dsonar.pullrequest.branch=${{ github.head_ref }} \
+              -Dsonar.pullrequest.base=${{ github.base_ref }} \
+              -Dsonar.host.url=$SONAR_URL \
+              -Dsonar.token=$SONAR_TOKEN
+          else
+            sonar-scanner \
+              -Dsonar.projectKey=activemq-classic-hawtio \
+              -Dsonar.projectName="ActiveMQ Classic Hawtio Plugin" \
+              -Dsonar.sources=src/main/java,frontend/src \
+              -Dsonar.java.binaries=target/classes \
+              -Dsonar.java.libraries="$SONAR_JAVA_LIBS" \
+              -Dsonar.scanner.javaExePath="$JAVA_HOME/bin/java" \
+              -Dsonar.qualitygate.wait=false \
+              -Dsonar.branch.name=${{ github.head_ref || github.ref_name }} \
+              -Dsonar.host.url=$SONAR_URL \
+              -Dsonar.token=$SONAR_TOKEN
+          fi

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: Code Scanning
+
+"on":
+  push:
+    branches: [ master, "1.0" ]
+  pull_request:
+    branches: [ master, "1.0" ]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ "java-kotlin", "javascript-typescript" ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Setup Java
+        if: ${{ matrix.language == 'java-kotlin' }}
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Node
+        if: ${{ matrix.language == 'javascript-typescript' }}
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/release-1.0.yml
+++ b/.github/workflows/release-1.0.yml
@@ -18,9 +18,39 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Detect releasable commits
+        id: releasable
+        run: |
+          git fetch --tags --force
+          LAST_RELEASE_COMMIT=$(git log --grep='^chore([^)]*): release ' --format=%H -n 1 || true)
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || true)
+
+          if [[ -n "$LAST_RELEASE_COMMIT" ]]; then
+            RANGE="$LAST_RELEASE_COMMIT..HEAD"
+          elif [[ -n "$LAST_TAG" ]]; then
+            RANGE="$LAST_TAG..HEAD"
+          else
+            RANGE="HEAD"
+          fi
+
+          echo "Using commit range: $RANGE"
+          git log --format=%s "$RANGE" | cat
+
+          if git log --format=%s "$RANGE" | grep -Eq '^(feat|fix|perf|revert|deps)(\(.+\))?(!)?:'; then
+            echo "has_releasable=true" >> "$GITHUB_OUTPUT"
+            echo "Releasable commits found."
+          else
+            echo "has_releasable=false" >> "$GITHUB_OUTPUT"
+            echo "No releasable commits found since the last release baseline; skipping release-please."
+          fi
 
       - name: Release Please
         id: release
+        if: ${{ steps.releasable.outputs.has_releasable == 'true' }}
         uses: googleapis/release-please-action@v5
         with:
           config-file: .release-please-config.json
@@ -93,11 +123,14 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_URL: ${{ secrets.SONAR_URL }}
         run: |
+          SONAR_JAVA_LIBS="${HOME}/.m2/repository/**/*.jar"
+
           sonar-scanner \
             -Dsonar.projectKey=activemq-classic-hawtio \
             -Dsonar.projectName="ActiveMQ Classic Hawtio Plugin" \
             -Dsonar.sources=src/main/java,frontend/src \
             -Dsonar.java.binaries=target/classes \
+            -Dsonar.java.libraries="$SONAR_JAVA_LIBS" \
             -Dsonar.scanner.javaExePath="$JAVA_HOME/bin/java" \
             -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }} \
             -Dsonar.host.url=$SONAR_URL \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,11 +188,14 @@ jobs:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_URL: ${{ secrets.SONAR_URL }}
         run: |
+          SONAR_JAVA_LIBS="${HOME}/.m2/repository/**/*.jar"
+
           sonar-scanner \
             -Dsonar.projectKey=activemq-classic-hawtio \
             -Dsonar.projectName="ActiveMQ Classic Hawtio Plugin" \
             -Dsonar.sources=src/main/java,frontend/src \
             -Dsonar.java.binaries=target/classes \
+            -Dsonar.java.libraries="$SONAR_JAVA_LIBS" \
             -Dsonar.scanner.javaExePath="$JAVA_HOME/bin/java" \
             -Dsonar.branch.name=${{ github.event.workflow_run.head_branch }} \
             -Dsonar.host.url=$SONAR_URL \

--- a/API.md
+++ b/API.md
@@ -142,6 +142,17 @@ getQueue(mbean)
 ```
 
 Returns a single queue.
+The returned queue model now includes message groups metadata when broker exposes it:
+
+```ts
+queue.messageGroups?: {
+	supported: boolean
+	type: string | null
+	groups: Array<{ id: string; consumerId: string | null; state: 'assigned' | 'unassigned' }>
+	totals: { total: number; assigned: number; unassigned: number }
+} | null
+```
+
 ```ts
 listQueuesWithRawAttributes(brokerName)
 ```

--- a/Architecture.md
+++ b/Architecture.md
@@ -105,6 +105,7 @@ Pannelli:
 - QueueStorage  
 - QueueDLQ  
 - QueueConsumers  
+- QueueMessageGroups  
 - QueueOperations  
 - QueueBrowser  
 

--- a/frontend/src/components/Common/MessageModal.tsx
+++ b/frontend/src/components/Common/MessageModal.tsx
@@ -73,7 +73,6 @@ export const MessageModal: React.FC<MessageModalProps> = ({ message, isOpen, onC
     <CodeBlockAction>
       <ClipboardCopyButton
         id="copy-body-button"
-        textId="message-body"
         aria-label="Copy to clipboard"
         onClick={handleCopyClick}
       >
@@ -83,7 +82,7 @@ export const MessageModal: React.FC<MessageModalProps> = ({ message, isOpen, onC
   );
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} variant="large">
+    <Modal isOpen={isOpen} onClose={onClose} variant="large" aria-label="Message Details">
       <ModalHeader>
         <h2 ref={headerRef} tabIndex={-1}>Message Details</h2>
       </ModalHeader>

--- a/frontend/src/components/Queues/DeleteQueueModal.tsx
+++ b/frontend/src/components/Queues/DeleteQueueModal.tsx
@@ -26,8 +26,8 @@ export const DeleteQueueModal: React.FC<DeleteQueueModalProps> = ({
     onConfirm={onConfirm}
   >
     <p>
-      This will permanently delete the queue <strong>{queueName}</strong>  
-      and all of its messages.  
+      This will permanently delete the queue <strong>{queueName}</strong>{' '}
+      and all of its messages.{' '}
       This action cannot be undone.
     </p>
   </BaseModal>

--- a/frontend/src/components/Queues/QueueDetailsPage.tsx
+++ b/frontend/src/components/Queues/QueueDetailsPage.tsx
@@ -26,6 +26,7 @@ import { QueueAlerts } from './QueueAlerts'
 import { QueueStorage } from './QueueStorage'
 import { QueueDLQ } from './QueueDLQ'
 import { QueueConsumers } from './QueueConsumers'
+import { QueueMessageGroups } from './QueueMessageGroups'
 
 import { useQueueMetrics } from '../../hooks/useQueueMetrics'
 import { useSelectedBrokerName } from '../../hooks/useSelectedBroker'
@@ -42,7 +43,7 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
   }, [])
 
     // SWR: carica la queue
-  const { data: queue, isLoading: queueLoading } = useQueue(brokerName, queueName)
+  const { data: queue, isLoading: queueLoading, mutate: refreshQueue } = useQueue(brokerName, queueName)
 
   // SWR: carica metriche
   const [autoRefresh, setAutoRefresh] = useState(false)
@@ -56,7 +57,10 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
   const handleManualRefresh = useCallback(() => {
     poll()
   }, [poll])
-  const handleNoopAction = useCallback(async () => {}, [])
+  const handleQueueAction = useCallback(async () => {
+    await refreshQueue()
+    poll()
+  }, [refreshQueue, poll])
 
   if (!brokerName) {
     return (
@@ -128,6 +132,7 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
           <Tab eventKey="metrics" title={<TabTitleText>Metrics</TabTitleText>} />
           <Tab eventKey="messages" title={<TabTitleText>Messages</TabTitleText>} />
           <Tab eventKey="consumers" title={<TabTitleText>Consumers</TabTitleText>} />
+          <Tab eventKey="message-groups" title={<TabTitleText>Message Groups</TabTitleText>} />
           <Tab eventKey="storage" title={<TabTitleText>Storage</TabTitleText>} />
           <Tab eventKey="dlq" title={<TabTitleText>DLQ</TabTitleText>} />
           <Tab eventKey="attributes" title={<TabTitleText>Attributes</TabTitleText>} />
@@ -159,6 +164,10 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
           <QueueConsumers queue={latest} history={history} />
         )}
 
+        {activeTab === 'message-groups' && (
+          <QueueMessageGroups queue={queue} onAction={handleQueueAction} />
+        )}
+
         {activeTab === 'storage' && <QueueStorage queue={latest} />}
 
         {activeTab === 'dlq' && <QueueDLQ queue={latest} />}
@@ -181,7 +190,7 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
 
 
         {activeTab === 'operations' && (
-          <QueueOperations queue={queue} onAction={handleNoopAction} />
+          <QueueOperations queue={queue} onAction={handleQueueAction} />
         )}
       </PageSection>
     </>

--- a/frontend/src/components/Queues/QueueMessageGroups.tsx
+++ b/frontend/src/components/Queues/QueueMessageGroups.tsx
@@ -1,0 +1,226 @@
+import React, { useCallback, useMemo, useState } from 'react'
+import {
+  Alert,
+  Button,
+  ButtonVariant,
+  Card,
+  CardBody,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateFooter,
+  Label,
+  Spinner,
+  Title,
+} from '@patternfly/react-core'
+import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table'
+import { ExclamationCircleIcon, TimesIcon, TrashIcon } from '@patternfly/react-icons'
+
+import { Queue } from '../../types/domain'
+import { activemq } from '../../services/activemq/ActiveMQClassicService'
+import { useQueueMessageGroups } from '../../hooks/useQueueMessageGroups'
+import { RefreshToolbar } from '../Common/RefreshControls'
+import { BaseModal } from './BaseModal'
+
+interface Props {
+  queue: Queue
+  onAction: () => Promise<void>
+}
+
+const dangerActionsStyle = { marginBottom: '1rem' }
+const removeAllButtonStyle = { marginLeft: '0.5rem' }
+
+export const QueueMessageGroups: React.FC<Props> = ({ queue, onAction }) => {
+  const [autoRefresh, setAutoRefresh] = useState(false)
+  const [interval, setInterval] = useState(5000)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isRemoveAllOpen, setIsRemoveAllOpen] = useState(false)
+  const [groupToRemove, setGroupToRemove] = useState<string | null>(null)
+
+  const { data, error, isLoading, mutate } = useQueueMessageGroups(queue.mbean, autoRefresh, interval)
+
+  const handleManualRefresh = useCallback(() => {
+    mutate()
+  }, [mutate])
+
+  const handleOpenRemoveAll = useCallback(() => {
+    setIsRemoveAllOpen(true)
+  }, [])
+
+  const handleCloseRemoveAll = useCallback(() => {
+    setIsRemoveAllOpen(false)
+  }, [])
+
+  const handleCloseRemoveSingle = useCallback(() => {
+    setGroupToRemove(null)
+  }, [])
+
+  const handleSelectGroupToRemove = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const groupId = event.currentTarget.dataset.groupId
+    if (groupId) {
+      setGroupToRemove(groupId)
+    }
+  }, [])
+
+  const handleRemoveAll = useCallback(async () => {
+    setIsSubmitting(true)
+
+    try {
+      await activemq.removeAllMessageGroups(queue.mbean)
+      await mutate()
+      await onAction()
+    } finally {
+      setIsSubmitting(false)
+      setIsRemoveAllOpen(false)
+    }
+  }, [mutate, onAction, queue.mbean])
+
+  const handleRemoveSingle = useCallback(async () => {
+    if (!groupToRemove) return
+
+    setIsSubmitting(true)
+
+    try {
+      await activemq.removeMessageGroup(queue.mbean, groupToRemove)
+      await mutate()
+      await onAction()
+    } finally {
+      setIsSubmitting(false)
+      setGroupToRemove(null)
+    }
+  }, [groupToRemove, mutate, onAction, queue.mbean])
+
+  const groups = useMemo(
+    () => [...(data?.groups ?? [])].sort((a, b) => a.id.localeCompare(b.id)),
+    [data?.groups]
+  )
+
+  return (
+    <Card isCompact>
+      <CardBody>
+        <Title headingLevel="h4">Message Groups</Title>
+
+        <RefreshToolbar
+          autoRefresh={autoRefresh}
+          onToggle={setAutoRefresh}
+          interval={interval}
+          onIntervalChange={setInterval}
+          onManualRefresh={handleManualRefresh}
+        />
+
+        {isLoading && (
+          <div>
+            <Spinner size="xl" />
+          </div>
+        )}
+
+        {error && (
+          <Alert variant="danger" title="Failed to load message groups" isInline>
+            Try refreshing and check broker connectivity.
+          </Alert>
+        )}
+
+        {!isLoading && !error && !data && (
+          <Alert variant="info" title="Message groups are not available for this queue" isInline />
+        )}
+
+        {!isLoading && !error && data && (
+          <>
+            <div style={dangerActionsStyle}>
+              {data.type && <Label color="blue">Type: {data.type}</Label>}
+              <Label color="blue" style={removeAllButtonStyle}>Total: {data.totals.total}</Label>
+              <Label color="green" style={removeAllButtonStyle}>Assigned: {data.totals.assigned}</Label>
+              <Label color="orange" style={removeAllButtonStyle}>Unassigned: {data.totals.unassigned}</Label>
+            </div>
+
+            <div style={dangerActionsStyle}>
+              <Button
+                variant="danger"
+                icon={<TrashIcon />}
+                isDisabled={data.totals.total === 0 || isSubmitting}
+                onClick={handleOpenRemoveAll}
+              >
+                Clear All Groups
+              </Button>
+            </div>
+
+            {groups.length === 0 && (
+              <EmptyState titleText="No active message groups" headingLevel="h4" icon={ExclamationCircleIcon}>
+                <EmptyStateBody>
+                  No group is currently locked to a consumer.
+                </EmptyStateBody>
+                <EmptyStateFooter>
+                  Use Refresh to check for updates.
+                </EmptyStateFooter>
+              </EmptyState>
+            )}
+
+            {groups.length > 0 && (
+              <Table variant="compact" aria-label="Queue message groups table">
+                <Thead>
+                  <Tr>
+                    <Th>Group</Th>
+                    <Th>Consumer</Th>
+                    <Th>State</Th>
+                    <Th modifier="fitContent">Actions</Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {groups.map(group => (
+                    <Tr key={group.id}>
+                      <Td>{group.id}</Td>
+                      <Td>{group.consumerId ?? '—'}</Td>
+                      <Td>
+                        <Label color={group.state === 'assigned' ? 'green' : 'orange'}>
+                          {group.state}
+                        </Label>
+                      </Td>
+                      <Td>
+                        <Button
+                          variant="danger"
+                          icon={<TimesIcon />}
+                          isDisabled={isSubmitting}
+                          data-group-id={group.id}
+                          onClick={handleSelectGroupToRemove}
+                        >
+                          Remove
+                        </Button>
+                      </Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            )}
+          </>
+        )}
+
+        <BaseModal
+          title="Clear all message groups"
+          isOpen={isRemoveAllOpen}
+          onClose={handleCloseRemoveAll}
+          confirmLabel="Clear All"
+          confirmIcon={<TrashIcon />}
+          confirmVariant={ButtonVariant.danger}
+          isConfirmDisabled={isSubmitting}
+          onConfirm={handleRemoveAll}
+        >
+          This will remove every active message group lock on queue {queue.name}.
+        </BaseModal>
+
+        <BaseModal
+          title="Remove message group"
+          isOpen={groupToRemove !== null}
+          onClose={handleCloseRemoveSingle}
+          confirmLabel="Remove Group"
+          confirmIcon={<TimesIcon />}
+          confirmVariant={ButtonVariant.danger}
+          isConfirmDisabled={isSubmitting}
+          onConfirm={handleRemoveSingle}
+        >
+          {groupToRemove
+            ? `This will remove message group ${groupToRemove} from queue ${queue.name}.`
+            : 'Select a message group to remove.'}
+        </BaseModal>
+      </CardBody>
+    </Card>
+  )
+}

--- a/frontend/src/hooks/useQueueMessageGroups.ts
+++ b/frontend/src/hooks/useQueueMessageGroups.ts
@@ -1,0 +1,21 @@
+import useSWR from 'swr'
+import { activemq } from '../services/activemq/ActiveMQClassicService'
+import { QueueMessageGroupsInfo } from '../types/domain'
+
+export function useQueueMessageGroups(
+  mbean: string,
+  autoRefresh: boolean,
+  interval: number
+) {
+  return useSWR<QueueMessageGroupsInfo | null>(
+    mbean ? ['queue-message-groups', mbean] : null,
+    async () => {
+      const queue = await activemq.getQueue(mbean)
+      return queue?.messageGroups ?? null
+    },
+    {
+      revalidateOnFocus: false,
+      refreshInterval: autoRefresh ? interval : 0,
+    }
+  )
+}

--- a/frontend/src/types/domain/index.ts
+++ b/frontend/src/types/domain/index.ts
@@ -7,6 +7,8 @@ export { mapSubscription } from './subscription'
 export type { Queue } from './queue'
 export { mapQueue } from './queue'
 
+export type { QueueMessageGroup, QueueMessageGroupsInfo } from './messageGroup'
+
 export type { Topic } from './topic'
 export { mapTopic } from './topic'
 

--- a/frontend/src/types/domain/messageGroup.ts
+++ b/frontend/src/types/domain/messageGroup.ts
@@ -1,0 +1,18 @@
+export type QueueMessageGroupState = 'assigned' | 'unassigned'
+
+export interface QueueMessageGroup {
+  id: string
+  consumerId: string | null
+  state: QueueMessageGroupState
+}
+
+export interface QueueMessageGroupsInfo {
+  supported: boolean
+  type: string | null
+  groups: QueueMessageGroup[]
+  totals: {
+    total: number
+    assigned: number
+    unassigned: number
+  }
+}

--- a/frontend/src/types/domain/queue.ts
+++ b/frontend/src/types/domain/queue.ts
@@ -1,4 +1,5 @@
 import { ActiveMQQueueAttributes } from '../activemq'
+import { QueueMessageGroup, QueueMessageGroupsInfo } from './messageGroup'
 import { mapSubscription, Subscription } from './subscription'
 
 export interface Queue {
@@ -31,8 +32,142 @@ export interface Queue {
   }
 
   subscriptions?: Subscription[]
+  messageGroups?: QueueMessageGroupsInfo | null
 
   timestamp: number
+}
+
+function toStringOrNull(value: unknown): string | null {
+  if (value === null || value === undefined) return null
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : null
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return String(value)
+  }
+
+  if (typeof value === 'object') {
+    return stringifyObjectValue(value as Record<string, unknown>)
+  }
+
+  return null
+}
+
+function stringifyObjectValue(value: Record<string, unknown>): string | null {
+  const knownKeys = ['consumerId', 'ConsumerId', 'clientId', 'ClientId', 'connectionId', 'ConnectionId', 'value']
+  const nestedValue = readFirstKnownKey(value, knownKeys)
+  if (nestedValue) return nestedValue
+
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return null
+  }
+}
+
+function readFirstKnownKey(
+  value: Record<string, unknown>,
+  keys: string[]
+): string | null {
+  for (const key of keys) {
+    if (!(key in value)) continue
+
+    const nested = toStringOrNull(value[key])
+    if (nested) return nested
+  }
+
+  return null
+}
+
+function flattenEntries(raw: unknown): Array<[string, string | null]> {
+  if (!raw) return []
+
+  if (Array.isArray(raw)) {
+    return raw.flatMap(item => flattenEntries(item))
+  }
+
+  if (typeof raw !== 'object') return []
+
+  const value = raw as Record<string, unknown>
+  const nestedEntries = flattenNestedEntries(value)
+  if (nestedEntries.length > 0) return nestedEntries
+
+  const rowEntry = mapRowEntry(value)
+  if (rowEntry) return [rowEntry]
+
+  return mapPrimitiveEntries(value)
+}
+
+function flattenNestedEntries(value: Record<string, unknown>): Array<[string, string | null]> {
+  const nestedKeys = ['entries', 'Entries', 'map', 'Map', 'value', 'Value', 'Contents', 'content']
+
+  for (const key of nestedKeys) {
+    if (!(key in value)) continue
+
+    const nested = flattenEntries(value[key])
+    if (nested.length > 0) return nested
+  }
+
+  return []
+}
+
+function mapRowEntry(value: Record<string, unknown>): [string, string | null] | null {
+  const rowKey = readFirstKnownKey(value, GROUP_ID_CANDIDATE_KEYS)
+  if (!rowKey) return null
+
+  const rowValue = readFirstKnownKey(value, GROUP_CONSUMER_CANDIDATE_KEYS)
+  return [rowKey, rowValue]
+}
+
+function mapPrimitiveEntries(value: Record<string, unknown>): Array<[string, string | null]> {
+  const primitiveEntries = Object.entries(value).filter(([, v]) => {
+    const type = typeof v
+    return v === null || type === 'string' || type === 'number' || type === 'boolean'
+  })
+
+  return primitiveEntries
+    .map(([k, v]) => [k, toStringOrNull(v)] as [string, string | null])
+    .filter(([k]) => k.length > 0)
+}
+
+  const GROUP_ID_CANDIDATE_KEYS = ['groupId', 'GroupId', 'group', 'Group', 'key', 'Key', 'name', 'Name']
+  const GROUP_CONSUMER_CANDIDATE_KEYS = ['consumerId', 'ConsumerId', 'consumer', 'Consumer', 'value', 'Value']
+
+function mapMessageGroups(a: ActiveMQQueueAttributes): QueueMessageGroupsInfo | null {
+  const hasGroupData = a.MessageGroups !== undefined && a.MessageGroups !== null
+  const hasGroupType = a.MessageGroupType !== undefined && a.MessageGroupType !== null
+
+  if (!hasGroupData && !hasGroupType) {
+    return null
+  }
+
+  const rawEntries = flattenEntries(a.MessageGroups)
+
+  const groups: QueueMessageGroup[] = rawEntries.map(([id, consumerId]) => {
+    const normalizedConsumer = toStringOrNull(consumerId)
+
+    return {
+      id,
+      consumerId: normalizedConsumer,
+      state: normalizedConsumer ? 'assigned' : 'unassigned',
+    }
+  })
+
+  const assigned = groups.filter(g => g.state === 'assigned').length
+
+  return {
+    supported: true,
+    type: toStringOrNull(a.MessageGroupType),
+    groups,
+    totals: {
+      total: groups.length,
+      assigned,
+      unassigned: groups.length - assigned,
+    },
+  }
 }
 
 export function mapQueue(mbean: string, a: ActiveMQQueueAttributes): Queue {
@@ -65,6 +200,7 @@ export function mapQueue(mbean: string, a: ActiveMQQueueAttributes): Queue {
     },
 
     subscriptions: a.Subscriptions?.map(mapSubscription),
+    messageGroups: mapMessageGroups(a),
     timestamp: Date.now(),
   }
 }

--- a/frontend/test/components/Common/MessageModal.test.tsx
+++ b/frontend/test/components/Common/MessageModal.test.tsx
@@ -43,8 +43,9 @@ describe('MessageModal', () => {
 
     render(<MessageModal isOpen={true} message={message} onClose={noop} />)
 
-    // PatternFly Modal usa un portal → il contenuto è in document.body
-    const codeBlock = document.body.querySelector('.pf-v5-c-code-block')
+    // PatternFly Modal usa un portal -> il contenuto e' in document.body.
+    // Avoid hardcoding PF major class names (v5/v6) in selectors.
+    const codeBlock = document.body.querySelector('[class*="c-code-block"]')
 
     expect(codeBlock).not.toBeNull()
     expect(codeBlock).toHaveStyle('overflow-y: auto')

--- a/frontend/test/types/domain/queue.test.ts
+++ b/frontend/test/types/domain/queue.test.ts
@@ -1,0 +1,74 @@
+import { mapQueue } from '../../../src/types/domain/queue'
+import { ActiveMQQueueAttributes } from '../../../src/types/activemq'
+
+function makeQueueAttrs(overrides: Partial<ActiveMQQueueAttributes> = {}): ActiveMQQueueAttributes {
+  return {
+    Name: 'orders',
+    QueueSize: 10,
+    EnqueueCount: 100,
+    DequeueCount: 90,
+    DispatchCount: 95,
+    ConsumerCount: 2,
+    ProducerCount: 1,
+    MemoryLimit: 1024,
+    MemoryUsageByteCount: 512,
+    MemoryPercentUsage: 50,
+    Paused: false,
+    Stopped: false,
+    Dlq: false,
+    Subscriptions: [],
+    ...overrides,
+  }
+}
+
+describe('mapQueue message groups', () => {
+  test('maps flat message groups object to group list and totals', () => {
+    const attrs = makeQueueAttrs({
+      MessageGroupType: 'simple',
+      MessageGroups: {
+        groupA: 'consumer-1',
+        groupB: '',
+      },
+    })
+
+    const queue = mapQueue('org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=orders', attrs)
+
+    expect(queue.messageGroups).not.toBeNull()
+    expect(queue.messageGroups?.type).toBe('simple')
+    expect(queue.messageGroups?.totals.total).toBe(2)
+    expect(queue.messageGroups?.totals.assigned).toBe(1)
+    expect(queue.messageGroups?.totals.unassigned).toBe(1)
+    expect(queue.messageGroups?.groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'groupA', consumerId: 'consumer-1', state: 'assigned' }),
+        expect.objectContaining({ id: 'groupB', consumerId: null, state: 'unassigned' }),
+      ])
+    )
+  })
+
+  test('supports nested tabular payload shape', () => {
+    const attrs = makeQueueAttrs({
+      MessageGroupType: 'cached',
+      MessageGroups: {
+        Entries: [
+          { GroupId: 'alpha', ConsumerId: 'consumer-a' },
+          { GroupId: 'beta', ConsumerId: null },
+        ],
+      },
+    })
+
+    const queue = mapQueue('org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=orders', attrs)
+
+    expect(queue.messageGroups?.totals.total).toBe(2)
+    expect(queue.messageGroups?.totals.assigned).toBe(1)
+    expect(queue.messageGroups?.totals.unassigned).toBe(1)
+  })
+
+  test('returns null when message groups are not exposed by broker', () => {
+    const attrs = makeQueueAttrs()
+
+    const queue = mapQueue('org.apache.activemq:type=Broker,brokerName=localhost,destinationType=Queue,destinationName=orders', attrs)
+
+    expect(queue.messageGroups).toBeNull()
+  })
+})

--- a/src/main/java/eu/opensoftware/ActiveMQClassicPluginServlet.java
+++ b/src/main/java/eu/opensoftware/ActiveMQClassicPluginServlet.java
@@ -15,7 +15,11 @@ import org.slf4j.LoggerFactory;
 public class ActiveMQClassicPluginServlet extends HttpServlet {
 
     private static final Logger LOG = LoggerFactory.getLogger(ActiveMQClassicPluginServlet.class);
+    private static final String PATH_DELIMITER = "/";
+    private static final String DEFAULT_ENTRY_POINT_PARAM = "defaultEntryPoint";
+    private static final String DEFAULT_ENTRY_POINT_FALLBACK = "/remoteEntry.js";
     private final String pluginId;
+    private String defaultEntryPoint = DEFAULT_ENTRY_POINT_FALLBACK;
 
     public ActiveMQClassicPluginServlet() {
         super();
@@ -37,9 +41,17 @@ public class ActiveMQClassicPluginServlet extends HttpServlet {
     @Override
     public void init() {
         ServletContext ctx = getServletContext();
+        String configuredEntryPoint = getServletConfig().getInitParameter(DEFAULT_ENTRY_POINT_PARAM);
+        if (configuredEntryPoint != null && !configuredEntryPoint.isBlank()) {
+            defaultEntryPoint = configuredEntryPoint.startsWith(PATH_DELIMITER)
+                    ? configuredEntryPoint
+                    : PATH_DELIMITER + configuredEntryPoint;
+        }
+
         LOG.debug("=== Servlet INIT ===");
         LOG.debug("Context path: {}", ctx.getContextPath());
         LOG.debug("Servlet context name: {}", ctx.getServletContextName());
+        LOG.debug("Default entry point: {}", defaultEntryPoint);
         LOG.debug("Classloader: {}", this.getClass().getClassLoader());
         LOG.debug("Servlet mappings: {}", ctx.getServletRegistrations());
         LOG.debug("====================");
@@ -56,17 +68,24 @@ public class ActiveMQClassicPluginServlet extends HttpServlet {
         LOG.debug("Request {}", req);
         LOG.debug("Path {}", path);
         if (path == null || path.equals("/")) {
-            path = "/remoteEntry.js";
+            path = defaultEntryPoint;
             LOG.debug("Path is null or /, using remoteEntry path");
         }
 
-        String resourcePath  = "/" + pluginId + path;
+        String normalizedPath = path.startsWith(PATH_DELIMITER)
+                ? path
+                : PATH_DELIMITER + path;
+        String resourcePath = PATH_DELIMITER + pluginId + normalizedPath;
         LOG.debug("Resource path in JAR: {}", resourcePath);
         try (InputStream in = getClass().getResourceAsStream(resourcePath)) {
             LOG.debug("Writing to output stream....");
             if (in == null) {
                 LOG.debug("Output stream is NULL!!!");
-                resp.sendError(404, "Not found: " + resourcePath);
+                try {
+                    sendNotFound(resp, resourcePath);
+                } catch (IOException e) {
+                    LOG.error("Failed to send 404 for resource {}", resourcePath, e);
+                }
                 return;
             }
 
@@ -83,8 +102,21 @@ public class ActiveMQClassicPluginServlet extends HttpServlet {
             }
 
             LOG.debug("Writing streamed resource");
-            in.transferTo(resp.getOutputStream());
+            try {
+                writeResourceToResponse(in, resp);
+            } catch (IOException e) {
+                LOG.error("Failed to stream plugin resource {} to HTTP response", resourcePath, e);
+                return;
+            }
         }
         LOG.debug("End processing servlet request");
+    }
+
+    private void sendNotFound(HttpServletResponse resp, String resourcePath) throws IOException {
+        resp.sendError(HttpServletResponse.SC_NOT_FOUND, "Not found: " + resourcePath);
+    }
+
+    private void writeResourceToResponse(InputStream in, HttpServletResponse resp) throws IOException {
+        in.transferTo(resp.getOutputStream());
     }
 }


### PR DESCRIPTION
# Summary
- add Message Groups tab on queue details
- show current message group assignments and totals
- add actions to clear all groups and remove a single group
- add domain mapping and SWR hook for message groups
- harden modal test selector to avoid PF-major-specific class coupling
- add branch baseline verification rules in copilot instructions

# Validation
- yarn test --runInBand test/components/Common/MessageModal.test.tsx test/types/domain/queue.test.ts
 
# Notes
- branch target: 1.0 release line
- this PR is paired with a master/2.0 PR for the same issue