### PR TITLE
feat(queues): separate queue and message operations

### DIFF
--- a/.github/skills/activemq-implementation.md
+++ b/.github/skills/activemq-implementation.md
@@ -67,6 +67,9 @@ It is focused on real project structure and responsibilities, not hypothetical a
 - Do not add heavy dependencies if the existing stack can cover the feature.
 
 ## Branch And Release Rules (MUST)
+- `master` and `1.0` are different Hawtio version lines and must not be treated as interchangeable baselines.
+- `master` maps to the 2.x line (PatternFly 6 expectations); `1.0` maps to the 1.x line (PatternFly 5 compatibility).
+- Before porting changes between branches, validate branch-specific compatibility (UI framework APIs, dependency set, and build behavior).
 - Apply compatible changes to both `master` and `1.0`.
 - For `master`-only changes, document compatibility rationale explicitly.
 - For PatternFly-version-sensitive fixes, evaluate and apply per-branch as applicable.

--- a/frontend/src/components/Common/MessageTable.tsx
+++ b/frontend/src/components/Common/MessageTable.tsx
@@ -7,15 +7,18 @@ import {
   Th,
   Td
 } from '@patternfly/react-table'
+import { Button, Checkbox } from '@patternfly/react-core'
 import { Message } from '../../types/domain';
 import { MessageModal } from './MessageModal';
-import { Button } from '@patternfly/react-core'; 
 import { EllipsisVIcon } from '@patternfly/react-icons';
 
 interface Props {
   messages: Message[]
+  selectedMessageIds: string[]
   sortDirection: 'asc' | 'desc'
   onSort: (column: string) => void
+  onToggleMessage: (messageId: string, isSelected: boolean) => void
+  onToggleAll: (isSelected: boolean) => void
 }
 
 const bodyCellStyle = {
@@ -43,15 +46,25 @@ function previewBody(m: Message, maxLines: number = 2, maxChars: number = 120): 
 
 export const MessageTable: React.FC<Props> = ({
   messages,
+  selectedMessageIds,
   sortDirection,
-  onSort
+  onSort,
+  onToggleMessage,
+  onToggleAll,
 }) => {
   const [selected, setSelected] = useState<Message | null>(null)
+  const allSelected = messages.length > 0 && messages.every((message) => selectedMessageIds.includes(message.id))
 
   const onSortId = useCallback(() => onSort('id'), [onSort])
   const onSortTimestamp = useCallback(() => onSort('timestamp'), [onSort])
   const onSortPriority = useCallback(() => onSort('priority'), [onSort])
   const onSortSize = useCallback(() => onSort('size'), [onSort])
+  const onToggleAllMessages = useCallback((_: unknown, isSelected: boolean) => {
+    onToggleAll(isSelected)
+  }, [onToggleAll])
+  const onToggleMessageSelection = useCallback((messageId: string, isSelected: boolean) => {
+    onToggleMessage(messageId, isSelected)
+  }, [onToggleMessage])
   const onCloseDetails = useCallback(() => setSelected(null), [])
   const onOpenDetails = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     const index = Number(event.currentTarget.dataset.index)
@@ -106,6 +119,16 @@ export const MessageTable: React.FC<Props> = ({
         <Thead>
           <Tr>
 
+            {/* Select */}
+            <Th>
+              <Checkbox
+                id="messages-select-all"
+                label=""
+                isChecked={allSelected}
+                onChange={onToggleAllMessages}
+              />
+            </Th>
+
             {/* ID */}
             <Th
               sort={idSort}
@@ -146,6 +169,15 @@ export const MessageTable: React.FC<Props> = ({
         <Tbody>
           {messages.map((m, i) => (
             <Tr key={i}>
+              <Td>
+                <Checkbox
+                  id={`messages-select-${m.id}`}
+                  label=""
+                  isChecked={selectedMessageIds.includes(m.id)}
+                  onChange={(_: unknown, isSelected: boolean) => onToggleMessageSelection(m.id, isSelected)}
+                />
+              </Td>
+
               <Td>{m.id}</Td>
 
               <Td>
@@ -165,12 +197,14 @@ export const MessageTable: React.FC<Props> = ({
               </Td>
 
               <Td>
-                <Button icon={<EllipsisVIcon />}
+                <Button
                   variant="plain"
                   aria-label="Apri dettagli"
                   data-index={i}
                   onClick={onOpenDetails}
-                 />
+                >
+                  <EllipsisVIcon />
+                </Button>
               </Td>
             </Tr>
           ))}

--- a/frontend/src/components/Queues/CopyMessageModal.tsx
+++ b/frontend/src/components/Queues/CopyMessageModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { BaseModal } from "./BaseModal"
 import { CopyIcon } from "@patternfly/react-icons"
 import { FormModal } from "./FormModal"
@@ -6,30 +6,46 @@ import { FormModal } from "./FormModal"
 interface CopyMessageModalProps {
   isOpen: boolean
   onClose: () => void
-  onConfirm: (id: string, dest: string) => void
+  onConfirm: (messageIds: string[], dest: string) => void
+  messageIds: string[]
 }
 
 export const CopyMessageModal: React.FC<CopyMessageModalProps> = ({
-  isOpen, onClose, onConfirm
+  isOpen, onClose, onConfirm, messageIds
 }) => {
-  const [id, setId] = useState('')
   const [dest, setDest] = useState('')
-  const handleConfirm = useCallback(() => onConfirm(id, dest), [onConfirm, id, dest])
+  useEffect(() => {
+    if (!isOpen) {
+      setDest('')
+    }
+  }, [isOpen])
+  const handleConfirm = useCallback(() => onConfirm(messageIds, dest.trim()), [onConfirm, messageIds, dest])
   const fields = useMemo(() => [
-    { name: 'id', label: 'Message ID', required: true, value: id, onChange: (_: unknown, value: string) => setId(value) },
-    { name: 'dest', label: 'Destination', required: true, value: dest, onChange: (_: unknown, value: string) => setDest(value) }
-  ], [id, dest])
+    { name: 'dest', label: 'Destination queue', required: true, value: dest, onChange: (_: unknown, value: string) => setDest(value) }
+  ], [dest])
+  const summary = useMemo(() => {
+    if (messageIds.length === 0) {
+      return 'Select one or more messages to copy.'
+    }
+
+    if (messageIds.length === 1) {
+      return `This will copy message ${messageIds[0]} to another queue.`
+    }
+
+    return `This will copy ${messageIds.length} selected messages to another queue.`
+  }, [messageIds])
 
   return (
     <BaseModal
-      title="Copy Message"
+      title={messageIds.length === 1 ? 'Copy Message' : 'Copy Messages'}
       isOpen={isOpen}
       onClose={onClose}
       confirmLabel="Copy"
       confirmIcon={<CopyIcon />}
-      isConfirmDisabled={!id || !dest}
+      isConfirmDisabled={messageIds.length === 0 || !dest.trim()}
       onConfirm={handleConfirm}
     >
+      <p>{summary}</p>
       <FormModal fields={fields} />
     </BaseModal>
   )

--- a/frontend/src/components/Queues/MoveMessageModal.tsx
+++ b/frontend/src/components/Queues/MoveMessageModal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react"
+import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { ArrowRightIcon } from "@patternfly/react-icons"
 import { BaseModal } from "./BaseModal"
 import { FormModal } from "./FormModal"
@@ -6,30 +6,46 @@ import { FormModal } from "./FormModal"
 interface MoveMessageModalProps {
   isOpen: boolean
   onClose: () => void
-  onConfirm: (id: string, dest: string) => void
+  onConfirm: (messageIds: string[], dest: string) => void
+  messageIds: string[]
 }
 
 export const MoveMessageModal: React.FC<MoveMessageModalProps> = ({
-  isOpen, onClose, onConfirm
+  isOpen, onClose, onConfirm, messageIds
 }) => {
-  const [id, setId] = useState('')
   const [dest, setDest] = useState('')
-  const handleConfirm = useCallback(() => onConfirm(id, dest), [onConfirm, id, dest])
+  useEffect(() => {
+    if (!isOpen) {
+      setDest('')
+    }
+  }, [isOpen])
+  const handleConfirm = useCallback(() => onConfirm(messageIds, dest.trim()), [onConfirm, messageIds, dest])
   const fields = useMemo(() => [
-    { name: 'id', label: 'Message ID', required: true, value: id, onChange: (_: unknown, v: string) => setId(v) },
-    { name: 'dest', label: 'Destination', required: true, value: dest, onChange: (_: unknown, v: string) => setDest(v) }
-  ], [id, dest])
+    { name: 'dest', label: 'Destination queue', required: true, value: dest, onChange: (_: unknown, v: string) => setDest(v) }
+  ], [dest])
+  const summary = useMemo(() => {
+    if (messageIds.length === 0) {
+      return 'Select one or more messages to move.'
+    }
+
+    if (messageIds.length === 1) {
+      return `This will move message ${messageIds[0]} to another queue.`
+    }
+
+    return `This will move ${messageIds.length} selected messages to another queue.`
+  }, [messageIds])
 
   return (
     <BaseModal
-      title="Move Message"
+      title={messageIds.length === 1 ? 'Move Message' : 'Move Messages'}
       isOpen={isOpen}
       onClose={onClose}
       confirmLabel="Move"
       confirmIcon={<ArrowRightIcon />}
-      isConfirmDisabled={!id || !dest}
+      isConfirmDisabled={messageIds.length === 0 || !dest.trim()}
       onConfirm={handleConfirm}
     >
+      <p>{summary}</p>
       <FormModal
         fields={fields}
       />

--- a/frontend/src/components/Queues/QueueBrowser.tsx
+++ b/frontend/src/components/Queues/QueueBrowser.tsx
@@ -1,21 +1,33 @@
 import React, { useCallback, useState } from 'react'
 import {
+  Button,
   Card,
   CardBody,
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateHeader,
+  Label,
   Pagination,
   Spinner,
-  EmptyState,
-  EmptyStateBody
+  Toolbar,
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
 } from '@patternfly/react-core'
-import { ExclamationCircleIcon } from '@patternfly/react-icons';
 
 import { Queue, Message } from '../../types/domain'
 import { useQueueMessages } from '../../hooks/useQueueMessages'
 import { MessageTable } from '../Common/MessageTable'
 import { RefreshToolbar } from '../Common/RefreshControls'
+import { MoveMessageModal } from './MoveMessageModal'
+import { CopyMessageModal } from './CopyMessageModal'
+import { RemoveMessageModal } from './RemoveMessageModal'
+import { RetryMessageModal } from './RetryMessageModal'
+import { activemq } from '../../services/activemq/ActiveMQClassicService'
 
 interface Props {
   queue: Queue
+  onAction: () => Promise<void>
 }
 
 const spinnerStyle = { padding: '2rem', textAlign: 'center' as const }
@@ -27,38 +39,39 @@ const perPageOptions = [
   { title: '100', value: 100 },
 ]
 
-export const QueueBrowser: React.FC<Props> = ({ queue }) => {
-  const [page, setPage] = useState(0);
-  const [pageSize, setPageSize] = useState(20);
+export const QueueBrowser: React.FC<Props> = ({ queue, onAction }) => {
+  const [page, setPage] = useState(0)
+  const [pageSize, setPageSize] = useState(20)
+  const [sortBy, setSortBy] = useState<string | null>(null)
+  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc')
+  const [autoRefresh, setAutoRefresh] = useState(false)
+  const [interval, setInterval] = useState(5000)
+  const [selectedMessageIds, setSelectedMessageIds] = useState<string[]>([])
+  const [isMoveOpen, setMoveOpen] = useState(false)
+  const [isCopyOpen, setCopyOpen] = useState(false)
+  const [isRemoveOpen, setRemoveOpen] = useState(false)
+  const [isRetryOpen, setRetryOpen] = useState(false)
 
-  const [sortBy, setSortBy] = useState<string | null>(null);
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
-
-  const [autoRefresh, setAutoRefresh] = useState(false);
-  const [interval, setInterval] = useState(5000);
-
-  const { data, isLoading, error, mutate } = useQueueMessages(queue.mbean, autoRefresh, interval);
+  const { data, isLoading, error, mutate } = useQueueMessages(queue.mbean, autoRefresh, interval)
 
   const raw = data ?? []
+  const total = raw.length
 
-  // const messages: Message[] = data?.messages ?? [];
-  const total = raw?.length ?? 0;
-
-  const onSetPage = useCallback((_evt: any, newPage: number) => {
-    setPage(newPage - 1) // PatternFly pages are 1-based
+  const onSetPage = useCallback((_evt: unknown, newPage: number) => {
+    setPage(newPage - 1)
   }, [])
 
-  const onPerPageSelect = useCallback((_evt: any, newSize: number) => {
+  const onPerPageSelect = useCallback((_evt: unknown, newSize: number) => {
     setPageSize(newSize)
-    setPage(0) // reset alla prima pagina
+    setPage(0)
   }, [])
 
   const onManualRefresh = useCallback(() => {
     mutate()
   }, [mutate])
 
-  function getSortValue(msg: Message, sortBy: string) {
-    switch (sortBy) {
+  function getSortValue(msg: Message, column: string) {
+    switch (column) {
       case 'id':
         return msg.id
       case 'timestamp':
@@ -81,13 +94,11 @@ export const QueueBrowser: React.FC<Props> = ({ queue }) => {
     }
   }, [sortBy, sortDirection])
 
-  // 1. Sorting
-  let sorted = [...raw]
-
+  const sorted = [...raw]
   if (sortBy) {
     sorted.sort((a, b) => {
-      const va = getSortValue(a, sortBy as string) ?? 0;
-      const vb = getSortValue(b, sortBy as string) ?? 0;
+      const va = getSortValue(a, sortBy) ?? 0
+      const vb = getSortValue(b, sortBy) ?? 0
 
       if (va < vb) return sortDirection === 'asc' ? -1 : 1
       if (va > vb) return sortDirection === 'asc' ? 1 : -1
@@ -95,13 +106,79 @@ export const QueueBrowser: React.FC<Props> = ({ queue }) => {
     })
   }
 
-  // 2. Pagination
   const start = page * pageSize
   const messages = sorted.slice(start, start + pageSize)
+  const selectedMessageCount = selectedMessageIds.length
 
+  const handleToggleMessage = useCallback((messageId: string, isSelected: boolean) => {
+    setSelectedMessageIds((previous) => {
+      if (isSelected) {
+        return previous.includes(messageId) ? previous : [...previous, messageId]
+      }
+
+      return previous.filter((id) => id !== messageId)
+    })
+  }, [])
+
+  const handleToggleAll = useCallback((isSelected: boolean) => {
+    setSelectedMessageIds((previous) => {
+      const currentPageIds = messages.map((message) => message.id)
+
+      if (isSelected) {
+        return Array.from(new Set([...previous, ...currentPageIds]))
+      }
+
+      return previous.filter((id) => !currentPageIds.includes(id))
+    })
+  }, [messages])
+
+  const clearSelection = useCallback(() => {
+    setSelectedMessageIds([])
+  }, [])
+
+  const openMoveModal = useCallback(() => setMoveOpen(true), [])
+  const closeMoveModal = useCallback(() => setMoveOpen(false), [])
+  const openCopyModal = useCallback(() => setCopyOpen(true), [])
+  const closeCopyModal = useCallback(() => setCopyOpen(false), [])
+  const openRemoveModal = useCallback(() => setRemoveOpen(true), [])
+  const closeRemoveModal = useCallback(() => setRemoveOpen(false), [])
+  const openRetryModal = useCallback(() => setRetryOpen(true), [])
+  const closeRetryModal = useCallback(() => setRetryOpen(false), [])
+
+  const handleMoveConfirm = useCallback(async (messageIds: string[], destination: string) => {
+    await Promise.all(messageIds.map((messageId) => activemq.moveMessageTo(queue.mbean, messageId, destination)))
+    await mutate()
+    await onAction()
+    clearSelection()
+    setMoveOpen(false)
+  }, [clearSelection, mutate, onAction, queue.mbean])
+
+  const handleCopyConfirm = useCallback(async (messageIds: string[], destination: string) => {
+    await Promise.all(messageIds.map((messageId) => activemq.copyMessageTo(queue.mbean, messageId, destination)))
+    await mutate()
+    await onAction()
+    clearSelection()
+    setCopyOpen(false)
+  }, [clearSelection, mutate, onAction, queue.mbean])
+
+  const handleRemoveConfirm = useCallback(async (messageIds: string[]) => {
+    await Promise.all(messageIds.map((messageId) => activemq.removeMessage(queue.mbean, messageId)))
+    await mutate()
+    await onAction()
+    clearSelection()
+    setRemoveOpen(false)
+  }, [clearSelection, mutate, onAction, queue.mbean])
+
+  const handleRetryConfirm = useCallback(async (messageIds: string[]) => {
+    await Promise.all(messageIds.map((messageId) => activemq.retryMessage(queue.mbean, messageId)))
+    await mutate()
+    await onAction()
+    clearSelection()
+    setRetryOpen(false)
+  }, [clearSelection, mutate, onAction, queue.mbean])
 
   return (
-    <Card isCompact>
+    <Card isFlat isCompact>
       <CardBody>
         <RefreshToolbar
           autoRefresh={autoRefresh}
@@ -111,36 +188,75 @@ export const QueueBrowser: React.FC<Props> = ({ queue }) => {
           onManualRefresh={onManualRefresh}
         />
 
+        <Toolbar style={paginationStyle}>
+          <ToolbarContent>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Label color="blue">{selectedMessageCount} selected</Label>
+              </ToolbarItem>
+              <ToolbarItem>
+                <Button variant="secondary" isDisabled={selectedMessageCount === 0} onClick={openMoveModal}>
+                  Move selected
+                </Button>
+              </ToolbarItem>
+              <ToolbarItem>
+                <Button variant="secondary" isDisabled={selectedMessageCount === 0} onClick={openCopyModal}>
+                  Copy selected
+                </Button>
+              </ToolbarItem>
+              <ToolbarItem>
+                <Button variant="secondary" isDisabled={selectedMessageCount === 0} onClick={openRetryModal}>
+                  Retry selected
+                </Button>
+              </ToolbarItem>
+              <ToolbarItem>
+                <Button variant="danger" isDisabled={selectedMessageCount === 0} onClick={openRemoveModal}>
+                  Remove selected
+                </Button>
+              </ToolbarItem>
+              <ToolbarItem>
+                <Button variant="secondary" isDisabled={selectedMessageCount === 0} onClick={clearSelection}>
+                  Clear selection
+                </Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarContent>
+        </Toolbar>
 
-        {/* LOADING */}
         {isLoading && (
           <div style={spinnerStyle}>
             <Spinner size="xl" />
           </div>
         )}
 
-        {/* ERROR */}
         {error && (
-          <EmptyState titleText="Failed to load messages" headingLevel="h4" icon={ExclamationCircleIcon}>
+          <EmptyState>
+            <EmptyStateHeader titleText="Failed to load messages" headingLevel="h4" />
             <EmptyStateBody>
               Try refreshing or navigating to another page.
             </EmptyStateBody>
           </EmptyState>
         )}
 
-        {/* EMPTY STATE */}
         {!isLoading && !error && messages.length === 0 && (
-          <EmptyState titleText="No messages in this page" headingLevel="h4" icon={ExclamationCircleIcon}>
+          <EmptyState>
+            <EmptyStateHeader titleText="No messages in this page" headingLevel="h4" />
             <EmptyStateBody>
               Try navigating to another page or wait for new messages.
             </EmptyStateBody>
           </EmptyState>
         )}
 
-        {/* TABLE */}
         {!isLoading && !error && messages.length > 0 && (
           <>
-            <MessageTable messages={messages} sortDirection={sortDirection} onSort={handleSort} />
+            <MessageTable
+              messages={messages}
+              selectedMessageIds={selectedMessageIds}
+              sortDirection={sortDirection}
+              onSort={handleSort}
+              onToggleMessage={handleToggleMessage}
+              onToggleAll={handleToggleAll}
+            />
 
             <Pagination
               itemCount={total}
@@ -154,6 +270,33 @@ export const QueueBrowser: React.FC<Props> = ({ queue }) => {
           </>
         )}
 
+        <MoveMessageModal
+          isOpen={isMoveOpen}
+          onClose={closeMoveModal}
+          onConfirm={handleMoveConfirm}
+          messageIds={selectedMessageIds}
+        />
+
+        <CopyMessageModal
+          isOpen={isCopyOpen}
+          onClose={closeCopyModal}
+          onConfirm={handleCopyConfirm}
+          messageIds={selectedMessageIds}
+        />
+
+        <RemoveMessageModal
+          isOpen={isRemoveOpen}
+          onClose={closeRemoveModal}
+          onConfirm={handleRemoveConfirm}
+          messageIds={selectedMessageIds}
+        />
+
+        <RetryMessageModal
+          isOpen={isRetryOpen}
+          onClose={closeRetryModal}
+          onConfirm={handleRetryConfirm}
+          messageIds={selectedMessageIds}
+        />
       </CardBody>
     </Card>
   )

--- a/frontend/src/components/Queues/QueueDetailsPage.tsx
+++ b/frontend/src/components/Queues/QueueDetailsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react'
 import {
   PageSection,
+  PageSectionVariants,
   Title,
   Button,
   Grid,
@@ -26,7 +27,6 @@ import { QueueAlerts } from './QueueAlerts'
 import { QueueStorage } from './QueueStorage'
 import { QueueDLQ } from './QueueDLQ'
 import { QueueConsumers } from './QueueConsumers'
-import { QueueMessageGroups } from './QueueMessageGroups'
 
 import { useQueueMetrics } from '../../hooks/useQueueMetrics'
 import { useSelectedBrokerName } from '../../hooks/useSelectedBroker'
@@ -61,10 +61,9 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
     await refreshQueue()
     poll()
   }, [refreshQueue, poll])
-
   if (!brokerName) {
     return (
-      <Card isCompact>
+      <Card isFlat isCompact>
         <CardBody>
           <Alert variant="danger" title="No broker selected" isInline />
         </CardBody>
@@ -74,7 +73,7 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
 
   if (queueLoading || metricsLoading || !queue || !latest) {
     return (
-      <PageSection hasBodyWrapper={false}>
+      <PageSection>
         <Title headingLevel="h3">Loading queue {queueName}…</Title>
       </PageSection>
     )
@@ -83,7 +82,7 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
   return (
     <>
       {/* HEADER */}
-      <PageSection hasBodyWrapper={false} >
+      <PageSection variant={PageSectionVariants.light}>
         <Grid hasGutter>
           <GridItem span={8}>
             <Title headingLevel="h2">{queue.name}</Title>
@@ -100,8 +99,8 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
       </PageSection>
 
       {/* SUMMARY */}
-      <PageSection hasBodyWrapper={false}>
-        <Card >
+      <PageSection>
+        <Card isFlat>
           <CardBody>
             <Grid hasGutter>
               <GridItem span={2}><b>Size:</b> {queue.size}</GridItem>
@@ -123,7 +122,7 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
       </PageSection>
 
       {/* TABS */}
-      <PageSection hasBodyWrapper={false}>
+      <PageSection>
         <Tabs
           activeKey={activeTab}
           onSelect={handleTabSelect}
@@ -132,7 +131,6 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
           <Tab eventKey="metrics" title={<TabTitleText>Metrics</TabTitleText>} />
           <Tab eventKey="messages" title={<TabTitleText>Messages</TabTitleText>} />
           <Tab eventKey="consumers" title={<TabTitleText>Consumers</TabTitleText>} />
-          <Tab eventKey="message-groups" title={<TabTitleText>Message Groups</TabTitleText>} />
           <Tab eventKey="storage" title={<TabTitleText>Storage</TabTitleText>} />
           <Tab eventKey="dlq" title={<TabTitleText>DLQ</TabTitleText>} />
           <Tab eventKey="attributes" title={<TabTitleText>Attributes</TabTitleText>} />
@@ -142,7 +140,7 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
       </PageSection>
 
       {/* TAB CONTENT */}
-      <PageSection hasBodyWrapper={false}>
+      <PageSection>
         {activeTab === 'overview' && (
           <>
             <QueueHealth queue={latest} />
@@ -158,14 +156,10 @@ export const QueueDetailsPage: React.FC<{ queueName: string }> = ({ queueName })
           </>
         )}
 
-        {activeTab === 'messages' && <QueueBrowser queue={queue} />}
+        {activeTab === 'messages' && <QueueBrowser queue={queue} onAction={handleQueueAction} />}
 
         {activeTab === 'consumers' && (
           <QueueConsumers queue={latest} history={history} />
-        )}
-
-        {activeTab === 'message-groups' && (
-          <QueueMessageGroups queue={queue} onAction={handleQueueAction} />
         )}
 
         {activeTab === 'storage' && <QueueStorage queue={latest} />}

--- a/frontend/src/components/Queues/QueueOperations.tsx
+++ b/frontend/src/components/Queues/QueueOperations.tsx
@@ -1,10 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react'
-import { Button,} from '@patternfly/react-core'
+import { Button } from '@patternfly/react-core'
 import { Queue } from '../../types/domain'
-import { MoveMessageModal } from './MoveMessageModal'
-import { CopyMessageModal } from './CopyMessageModal'
-import { RemoveMessageModal } from './RemoveMessageModal'
-import { RetryMessageModal } from './RetryMessageModal'
 import { RemoveMessageGroupModal } from './RemoveMessageGroupModal'
 import { SendMessageModal } from './SendMessageModal'
 import { log } from '../../globals'
@@ -18,54 +14,52 @@ type HeaderEntry = {
 }
 
 export const QueueOperations: React.FC<{ queue: Queue, onAction: () => Promise<void> }> = ({ queue, onAction }) => {
-  const [isMoveOpen, setMoveOpen] = useState(false);
-  const [isCopyOpen, setCopyOpen] = useState(false);
-  const [isRemoveOpen, setRemoveOpen] = useState(false);
-  const [isRetryOpen, setRetryOpen] = useState(false);
-  const [isRemoveGroupOpen, setRemoveGroupOpen] = useState(false);
-  const [isSendOpen, setSendOpen] = useState(false);
-  const [queueModals, setQueueModals] = useState({ purge: false, delete: false });
-  const handleDeleteConfirm = useCallback(() => {
-    activemq.deleteQueue(queue.mbean, queue.name);
-    setQueueModals((prev) => ({ ...prev, delete: false }))
-  }, [queue])
+  const [isRemoveGroupOpen, setRemoveGroupOpen] = useState(false)
+  const [isSendOpen, setSendOpen] = useState(false)
+  const [queueModals, setQueueModals] = useState({ purge: false, delete: false })
+
   const handlePauseClick = useCallback(() => activemq.pauseQueue(queue.mbean), [queue])
   const handleResumeClick = useCallback(() => activemq.resumeQueue(queue.mbean), [queue])
+
+  const queueMessageModalHandlers = useMemo(
+    () => ({
+      openRemoveGroup: () => setRemoveGroupOpen(true),
+      closeRemoveGroup: () => setRemoveGroupOpen(false),
+      openSend: () => setSendOpen(true),
+      closeSend: () => setSendOpen(false),
+    }),
+    [],
+  )
+
+  const queueAdminModalHandlers = useMemo(
+    () => ({
+      openPurge: () => setQueueModals((prev) => ({ ...prev, purge: true })),
+      closePurge: () => setQueueModals((prev) => ({ ...prev, purge: false })),
+      openDelete: () => setQueueModals((prev) => ({ ...prev, delete: true })),
+      closeDelete: () => setQueueModals((prev) => ({ ...prev, delete: false })),
+    }),
+    [],
+  )
+
   const createConfirmHandler = useCallback(
     <T extends unknown[]>(
       actionName: string,
       action: (...args: T) => Promise<unknown>,
-      closeModal: React.Dispatch<React.SetStateAction<boolean>>,
+      closeModal: () => void,
     ) => {
       return async (...args: T) => {
         log.debug(actionName, ...args)
         await action(...args)
         await onAction()
-        closeModal(false)
+        closeModal()
       }
     },
     [onAction],
   )
 
-  const handleMoveConfirm = useMemo(
-    () => createConfirmHandler('MOVE', (id: string, dest: string) => activemq.moveMessageTo(queue.mbean, id, dest), setMoveOpen),
-    [createConfirmHandler, queue.mbean],
-  )
-  const handleCopyConfirm = useMemo(
-    () => createConfirmHandler('COPY', (id: string, dest: string) => activemq.copyMessageTo(queue.mbean, id, dest), setCopyOpen),
-    [createConfirmHandler, queue.mbean],
-  )
-  const handleRemoveConfirm = useMemo(
-    () => createConfirmHandler('REMOVE', (id: string) => activemq.removeMessage(queue.mbean, id), setRemoveOpen),
-    [createConfirmHandler, queue.mbean],
-  )
-  const handleRetryConfirm = useMemo(
-    () => createConfirmHandler('RETRY', (id: string) => activemq.retryMessage(queue.mbean, id), setRetryOpen),
-    [createConfirmHandler, queue.mbean],
-  )
   const handleRemoveGroupConfirm = useMemo(
-    () => createConfirmHandler('REMOVE GROUP', (group: string) => activemq.removeMessageGroup(queue.mbean, group), setRemoveGroupOpen),
-    [createConfirmHandler, queue.mbean],
+    () => createConfirmHandler('REMOVE GROUP', (group: string) => activemq.removeMessageGroup(queue.mbean, group), queueMessageModalHandlers.closeRemoveGroup),
+    [createConfirmHandler, queue.mbean, queueMessageModalHandlers.closeRemoveGroup],
   )
   const handleSendConfirm = useMemo(
     () =>
@@ -79,77 +73,27 @@ export const QueueOperations: React.FC<{ queue: Queue, onAction: () => Promise<v
           const headersMap = Object.fromEntries(headers.map(({ key, value }) => [key, value]))
           return activemq.sendTextMessageWithHeaders(queue.mbean, body, headersMap)
         },
-        setSendOpen,
+        queueMessageModalHandlers.closeSend,
       ),
-    [createConfirmHandler, queue.mbean],
+    [createConfirmHandler, queue.mbean, queueMessageModalHandlers.closeSend],
   )
-  const queueMessageModalHandlers = useMemo(
-    () => ({
-      openMove: () => setMoveOpen(true),
-      closeMove: () => setMoveOpen(false),
-      openCopy: () => setCopyOpen(true),
-      closeCopy: () => setCopyOpen(false),
-      openRemove: () => setRemoveOpen(true),
-      closeRemove: () => setRemoveOpen(false),
-      openRetry: () => setRetryOpen(true),
-      closeRetry: () => setRetryOpen(false),
-      openRemoveGroup: () => setRemoveGroupOpen(true),
-      closeRemoveGroup: () => setRemoveGroupOpen(false),
-      openSend: () => setSendOpen(true),
-      closeSend: () => setSendOpen(false),
-    }),
-    [],
+  const handlePurgeConfirm = useMemo(
+    () => createConfirmHandler('PURGE', () => activemq.purgeQueue(queue.mbean), queueAdminModalHandlers.closePurge),
+    [createConfirmHandler, queue.mbean, queueAdminModalHandlers.closePurge],
   )
-  const queueAdminModalHandlers = useMemo(
-    () => ({
-      openPurge: () => setQueueModals((prev) => ({ ...prev, purge: true })),
-      closePurge: () => setQueueModals((prev) => ({ ...prev, purge: false })),
-      openDelete: () => setQueueModals((prev) => ({ ...prev, delete: true })),
-      closeDelete: () => setQueueModals((prev) => ({ ...prev, delete: false })),
-    }),
-    [],
+  const handleDeleteConfirm = useMemo(
+    () => createConfirmHandler('DELETE QUEUE', () => activemq.deleteQueue(queue.mbean, queue.name), queueAdminModalHandlers.closeDelete),
+    [createConfirmHandler, queue.mbean, queue.name, queueAdminModalHandlers.closeDelete],
   )
-  const handlePurgeConfirm = useCallback(() => {
-    activemq.purgeQueue(queue.mbean)
-    queueAdminModalHandlers.closePurge()
-  }, [queue, queueAdminModalHandlers])
   
   return (
     <>
-      <Button onClick={queueMessageModalHandlers.openMove}>Move Message</Button>
-      <Button onClick={queueMessageModalHandlers.openCopy}>Copy Message</Button>
-      <Button onClick={queueMessageModalHandlers.openRemove}>Remove Message</Button>
-      <Button onClick={queueMessageModalHandlers.openRetry}>Retry Message</Button>
       <Button onClick={queueMessageModalHandlers.openRemoveGroup}>Remove Group</Button>
       <Button onClick={queueMessageModalHandlers.openSend}>Send Message</Button>
       <Button variant="secondary" isDisabled={queue.state.paused === true} onClick={handlePauseClick}>Pause</Button>
       <Button variant="secondary" isDisabled={queue.state.paused === false} onClick={handleResumeClick}>Resume</Button>
       <Button variant="danger" onClick={queueAdminModalHandlers.openPurge}>Purge</Button>
       <Button variant="danger" onClick={queueAdminModalHandlers.openDelete}>Delete Queue</Button>
-
-      <MoveMessageModal
-        isOpen={isMoveOpen}
-        onClose={queueMessageModalHandlers.closeMove}
-        onConfirm={handleMoveConfirm}
-      />
-
-      <CopyMessageModal
-        isOpen={isCopyOpen}
-        onClose={queueMessageModalHandlers.closeCopy}
-        onConfirm={handleCopyConfirm}
-      />
-
-      <RemoveMessageModal
-        isOpen={isRemoveOpen}
-        onClose={queueMessageModalHandlers.closeRemove}
-        onConfirm={handleRemoveConfirm}
-      />
-
-      <RetryMessageModal
-        isOpen={isRetryOpen}
-        onClose={queueMessageModalHandlers.closeRetry}
-        onConfirm={handleRetryConfirm}
-      />
 
       <RemoveMessageGroupModal
         isOpen={isRemoveGroupOpen}

--- a/frontend/src/components/Queues/RemoveMessageModal.tsx
+++ b/frontend/src/components/Queues/RemoveMessageModal.tsx
@@ -1,37 +1,43 @@
-import React, { useCallback, useMemo, useState } from "react"
+import React, { useCallback, useMemo } from "react"
 import { BaseModal } from "./BaseModal"
 import { TrashIcon } from "@patternfly/react-icons"
 import { ButtonVariant } from "@patternfly/react-core"
-import { FormModal } from "./FormModal"
 
 interface RemoveMessageModalProps {
   isOpen: boolean
   onClose: () => void
-  onConfirm: (id: string) => void
+  onConfirm: (messageIds: string[]) => void
+  messageIds: string[]
 }
 
 export const RemoveMessageModal: React.FC<RemoveMessageModalProps> = ({
-  isOpen, onClose, onConfirm
+  isOpen, onClose, onConfirm, messageIds
 }) => {
-  const [id, setId] = useState('')
-  const handleConfirm = useCallback(() => onConfirm(id), [onConfirm, id])
-  const handleIdChange = useCallback((_: unknown, v: string) => setId(v), [])
-  const fields = useMemo(() => [{ name: 'id', label: 'Message ID', required: true, value: id, onChange: handleIdChange }], [id, handleIdChange])
+  const handleConfirm = useCallback(() => onConfirm(messageIds), [onConfirm, messageIds])
+  const summary = useMemo(() => {
+    if (messageIds.length === 0) {
+      return 'Select one or more messages to remove.'
+    }
+
+    if (messageIds.length === 1) {
+      return `This will remove message ${messageIds[0]} from the queue.`
+    }
+
+    return `This will remove ${messageIds.length} selected messages from the queue.`
+  }, [messageIds])
 
   return (
     <BaseModal
-      title="Remove Message"
+      title={messageIds.length === 1 ? 'Remove Message' : 'Remove Messages'}
       isOpen={isOpen}
       onClose={onClose}
       confirmLabel="Remove"
       confirmIcon={<TrashIcon />}
       confirmVariant={ButtonVariant.danger}
-      isConfirmDisabled={!id}
+      isConfirmDisabled={messageIds.length === 0}
       onConfirm={handleConfirm}
     >
-      <FormModal
-        fields={fields}
-      />
+      <p>{summary}</p>
     </BaseModal>
   )
 }

--- a/frontend/src/components/Queues/RetryMessageModal.tsx
+++ b/frontend/src/components/Queues/RetryMessageModal.tsx
@@ -1,35 +1,41 @@
-import React, { useCallback, useMemo, useState } from "react"
+import React, { useCallback, useMemo } from "react"
 import { BaseModal } from "./BaseModal"
 import { RedoIcon } from "@patternfly/react-icons"
-import { FormModal } from "./FormModal"
 
 interface RetryMessageModalProps {
   isOpen: boolean
   onClose: () => void
-  onConfirm: (id: string) => void
+  onConfirm: (messageIds: string[]) => void
+  messageIds: string[]
 }
 
 export const RetryMessageModal: React.FC<RetryMessageModalProps> = ({
-  isOpen, onClose, onConfirm
+  isOpen, onClose, onConfirm, messageIds
 }) => {
-  const [id, setId] = useState('')
-  const handleConfirm = useCallback(() => onConfirm(id), [onConfirm, id])
-  const handleIdChange = useCallback((_: unknown, value: string) => setId(value), [])
-  const fields = useMemo(() => [
-    { name: 'id', label: 'Message ID', required: true, value: id, onChange: handleIdChange }
-  ], [id, handleIdChange])
+  const handleConfirm = useCallback(() => onConfirm(messageIds), [onConfirm, messageIds])
+  const summary = useMemo(() => {
+    if (messageIds.length === 0) {
+      return 'Select one or more messages to retry.'
+    }
+
+    if (messageIds.length === 1) {
+      return `This will retry message ${messageIds[0]}.`
+    }
+
+    return `This will retry ${messageIds.length} selected messages.`
+  }, [messageIds])
 
   return (
     <BaseModal
-      title="Retry Message"
+      title={messageIds.length === 1 ? 'Retry Message' : 'Retry Messages'}
       isOpen={isOpen}
       onClose={onClose}
       confirmLabel="Retry"
       confirmIcon={<RedoIcon />}
-      isConfirmDisabled={!id}
+      isConfirmDisabled={messageIds.length === 0}
       onConfirm={handleConfirm}
     >
-      <FormModal fields={fields} />
+      <p>{summary}</p>
     </BaseModal>
   )
 }

--- a/frontend/test/components/Common/MessageTable.test.tsx
+++ b/frontend/test/components/Common/MessageTable.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import '@testing-library/jest-dom'
+
+import { MessageTable } from '../../../src/components/Common/MessageTable'
+import { makeMessage } from '../../utils/makeMessage'
+
+describe('MessageTable selection', () => {
+  test('renders row and header checkboxes and forwards selection changes', async () => {
+    const user = userEvent.setup()
+    const onToggleMessage = jest.fn()
+    const onToggleAll = jest.fn()
+
+    render(
+      <MessageTable
+        messages={[
+          makeMessage({ id: 'msg-1' }),
+          makeMessage({ id: 'msg-2' }),
+        ]}
+        selectedMessageIds={[]}
+        sortDirection="asc"
+        onSort={jest.fn()}
+        onToggleMessage={onToggleMessage}
+        onToggleAll={onToggleAll}
+      />,
+    )
+
+    const checkboxes = screen.getAllByRole('checkbox')
+
+    await user.click(checkboxes[1])
+    expect(onToggleMessage).toHaveBeenCalledWith('msg-1', true)
+
+    await user.click(checkboxes[0])
+    expect(onToggleAll).toHaveBeenCalledWith(true)
+  })
+})


### PR DESCRIPTION
# Pull Request

## Description
This PR separates queue-level operations from message-level operations in the queue details UI.

Queue-wide actions remain in the Operations tab, while bulk message actions are now handled directly in the message browser through row selection. This makes the queue workflow clearer and removes the need to manually type message IDs for move/copy/remove/retry actions.

The PR also makes the branch/version distinction explicit in the repository operational rules:
- `master` is the 2.x Hawtio line
- `1.0` is the 1.x Hawtio line
- cross-branch porting must be validated for compatibility

## Type of Change
- [x] feat (new feature)
- [ ] fix (bug fix)
- [ ] docs (documentation)
- [ ] refactor (no functional changes)
- [ ] chore (maintenance)
- [ ] ci (workflow changes)

## Checklist
- [x] My commits follow the Conventional Commits specification
- [x] If this PR is ready to merge, commits are squashed
- [ ] I added screenshots if the UI was modified
- [x] I tested the changes locally
- [x] I updated documentation where needed

## Related Issues
Related to the queue/message operations redesign discussed for the queue details view.